### PR TITLE
Fix Environment Variables and Registry Cleanup for KiCad 8

### DIFF
--- a/App/AppInfo/Launcher/KiCadPortable.ini
+++ b/App/AppInfo/Launcher/KiCadPortable.ini
@@ -8,12 +8,12 @@ WaitForEXE6=pl_editor.exe
 DirectoryMoveOK=yes
 
 [Environment]
-KICAD7_3DMODEL_DIR=%PAL:AppDir%\KiCad\share\kicad\3dmodels
-KICAD7_3RD_PARTY=%PAL:DataDir%\3rdparty
-KICAD7_FOOTPRINT_DIR=%PAL:AppDir%\KiCad\share\kicad\footprints
-KICAD7_SYMBOL_DIR=%PAL:AppDir%\KiCad\share\kicad\symbols
-KICAD7_SCRIPTING_DIR=%PAL:AppDir%\KiCad\share\kicad\scripting
-KICAD7_TEMPLATE_DIR=%PAL:AppDir%\KiCad\share\kicad\template
+KICAD8_3DMODEL_DIR=%PAL:AppDir%\KiCad\share\kicad\3dmodels
+KICAD8_3RD_PARTY=%PAL:DataDir%\3rdparty
+KICAD8_FOOTPRINT_DIR=%PAL:AppDir%\KiCad\share\kicad\footprints
+KICAD8_SYMBOL_DIR=%PAL:AppDir%\KiCad\share\kicad\symbols
+KICAD8_SCRIPTING_DIR=%PAL:AppDir%\KiCad\share\kicad\scripting
+KICAD8_TEMPLATE_DIR=%PAL:AppDir%\KiCad\share\kicad\template
 KICAD_CACHE_HOME=%PAL:DataDir%\Cache
 KICAD_CONFIG_HOME=%PAL:DataDir%\Config
 KICAD_USER_TEMPLATE_DIR=%PAL:DataDir%\template

--- a/App/AppInfo/Launcher/KiCadPortable.ini
+++ b/App/AppInfo/Launcher/KiCadPortable.ini
@@ -17,3 +17,9 @@ KICAD8_TEMPLATE_DIR=%PAL:AppDir%\KiCad\share\kicad\template
 KICAD_CACHE_HOME=%PAL:DataDir%\Cache
 KICAD_CONFIG_HOME=%PAL:DataDir%\Config
 KICAD_USER_TEMPLATE_DIR=%PAL:DataDir%\template
+
+[Activate]
+Registry=true
+
+[RegistryKeys]
+KiCad=HKCU\Software\KiCad


### PR DESCRIPTION
Changes:
- Updated environment variables for KiCad 8 directory paths.
- Implemented registry cleanup to ensure proper handling on exit (Related Issues)

Related Issues:
- https://portableapps.com/comment/258935#comment-258935